### PR TITLE
Switch from http to ssh so we can use the SSH keys and hit a private repo

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -206,7 +206,7 @@ if [ -e "$APP_SOURCE_DIR"/git-packages.json ]; then
   echo "-----> Installing mgp"
   $METEOR_NPM install -g mgp
   echo "-----> Installing the packages"
-  mgp --https
+  mgp
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and

--- a/bin/compile
+++ b/bin/compile
@@ -206,7 +206,11 @@ if [ -e "$APP_SOURCE_DIR"/git-packages.json ]; then
   echo "-----> Installing mgp"
   $METEOR_NPM install -g mgp
   echo "-----> Installing the packages"
-  mgp
+  if [ "$GIT_SSH_KEY" != "" ]; then
+    mgp
+  else
+    mgp --https
+  fi
 fi
 
 # Related to https://github.com/meteor/meteor/issues/2796 and


### PR DESCRIPTION
Switch from http to ssh so we can use the SSH keys and hit a private repo